### PR TITLE
feature type & assertion automation state

### DIFF
--- a/SpecBox.Domain/BulkCopy/BulkWriterAssertion.cs
+++ b/SpecBox.Domain/BulkCopy/BulkWriterAssertion.cs
@@ -27,6 +27,6 @@ public class BulkWriterAssertion : BulkWriter
         await Writer.WriteAsync(groupTitle, NpgsqlDbType.Text);
         await Writer.WriteAsync(title, NpgsqlDbType.Text);
         await Writer.WriteAsync(description, NpgsqlDbType.Text);
-        await Writer.WriteAsync(automationState, NpgsqlDbType.Integer);
+        await Writer.WriteAsync(Convert.ToInt32(automationState), NpgsqlDbType.Integer);
     }
 }

--- a/SpecBox.Domain/BulkCopy/BulkWriterAssertion.cs
+++ b/SpecBox.Domain/BulkCopy/BulkWriterAssertion.cs
@@ -1,12 +1,13 @@
 using Npgsql;
 using NpgsqlTypes;
+using SpecBox.Domain.Model.Enums;
 
 namespace SpecBox.Domain.BulkCopy;
 
 public class BulkWriterAssertion : BulkWriter
 {
     private const string COMMAND =
-        "COPY \"ExportAssertion\" (\"ExportId\", \"FeatureCode\",\"GroupTitle\",\"Title\",\"Description\", \"IsAutomated\") FROM STDIN (FORMAT BINARY)";
+        "COPY \"ExportAssertion\" (\"ExportId\", \"FeatureCode\",\"GroupTitle\",\"Title\",\"Description\", \"AutomationState\") FROM STDIN (FORMAT BINARY)";
 
     public BulkWriterAssertion(NpgsqlConnection connection) : base(COMMAND, connection)
     {
@@ -18,7 +19,7 @@ public class BulkWriterAssertion : BulkWriter
         string groupTitle,
         string title,
         string? description,
-        bool isAutomated)
+        AutomationState automationState)
     {
         await Writer.StartRowAsync();
         await Writer.WriteAsync(exportId, NpgsqlDbType.Uuid);
@@ -26,6 +27,6 @@ public class BulkWriterAssertion : BulkWriter
         await Writer.WriteAsync(groupTitle, NpgsqlDbType.Text);
         await Writer.WriteAsync(title, NpgsqlDbType.Text);
         await Writer.WriteAsync(description, NpgsqlDbType.Text);
-        await Writer.WriteAsync(isAutomated, NpgsqlDbType.Boolean);
+        await Writer.WriteAsync(automationState, NpgsqlDbType.Integer);
     }
 }

--- a/SpecBox.Domain/BulkCopy/BulkWriterFeature.cs
+++ b/SpecBox.Domain/BulkCopy/BulkWriterFeature.cs
@@ -13,6 +13,16 @@ public class BulkWriterFeature : BulkWriter
     {
     }
 
+    private int? ToNullableInt32(FeatureType? featureType)
+    {
+        if (featureType.HasValue)
+        {
+            return Convert.ToInt32(featureType.Value);
+        }
+
+        return null;
+    }
+
     public async Task AddFeature(
         Guid exportId,
         string code,
@@ -26,7 +36,7 @@ public class BulkWriterFeature : BulkWriter
         await Writer.WriteAsync(code, NpgsqlDbType.Text);
         await Writer.WriteAsync(title, NpgsqlDbType.Text);
         await Writer.WriteAsync(description, NpgsqlDbType.Text);
-        await Writer.WriteAsync(featureType, NpgsqlDbType.Integer);
+        await Writer.WriteAsync(ToNullableInt32(featureType), NpgsqlDbType.Integer);
         await Writer.WriteAsync(filePath, NpgsqlDbType.Text);
     }
 }

--- a/SpecBox.Domain/BulkCopy/BulkWriterFeature.cs
+++ b/SpecBox.Domain/BulkCopy/BulkWriterFeature.cs
@@ -1,12 +1,13 @@
 using Npgsql;
 using NpgsqlTypes;
+using SpecBox.Domain.Model.Enums;
 
 namespace SpecBox.Domain.BulkCopy;
 
 public class BulkWriterFeature : BulkWriter
 {
     private const string COMMAND =
-        "COPY \"ExportFeature\" (\"ExportId\", \"Code\",\"Title\",\"Description\", \"FilePath\") FROM STDIN (FORMAT BINARY)";
+        "COPY \"ExportFeature\" (\"ExportId\", \"Code\", \"Title\",\"Description\", \"FeatureType\", \"FilePath\") FROM STDIN (FORMAT BINARY)";
 
     public BulkWriterFeature(NpgsqlConnection connection) : base(COMMAND, connection)
     {
@@ -17,6 +18,7 @@ public class BulkWriterFeature : BulkWriter
         string code,
         string title,
         string? description,
+        FeatureType? featureType,
         string? filePath)
     {
         await Writer.StartRowAsync();
@@ -24,6 +26,7 @@ public class BulkWriterFeature : BulkWriter
         await Writer.WriteAsync(code, NpgsqlDbType.Text);
         await Writer.WriteAsync(title, NpgsqlDbType.Text);
         await Writer.WriteAsync(description, NpgsqlDbType.Text);
+        await Writer.WriteAsync(featureType, NpgsqlDbType.Integer);
         await Writer.WriteAsync(filePath, NpgsqlDbType.Text);
     }
 }

--- a/SpecBox.Domain/Model/Assertion.cs
+++ b/SpecBox.Domain/Model/Assertion.cs
@@ -11,9 +11,6 @@ public class Assertion
     public string Title { get; set; } = null!;
     public string? Description { get; set; }
 
-    [Obsolete("используйте поле AutomationState")]
-    public bool IsAutomated { get; set; }
-
     public AutomationState AutomationState { get; set; }
 
     public Guid AssertionGroupId { get; set; }

--- a/SpecBox.Domain/Model/Assertion.cs
+++ b/SpecBox.Domain/Model/Assertion.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using SpecBox.Domain.Model.Enums;
 
 namespace SpecBox.Domain.Model;
 
@@ -6,10 +7,14 @@ namespace SpecBox.Domain.Model;
 public class Assertion
 {
     public Guid Id { get; set; }
-    
+
     public string Title { get; set; } = null!;
     public string? Description { get; set; }
+
+    [Obsolete("используйте поле AutomationState")]
     public bool IsAutomated { get; set; }
+
+    public AutomationState AutomationState { get; set; }
 
     public Guid AssertionGroupId { get; set; }
     public AssertionGroup AssertionGroup { get; set; } = null!;

--- a/SpecBox.Domain/Model/AssertionsStatRecord.cs
+++ b/SpecBox.Domain/Model/AssertionsStatRecord.cs
@@ -16,4 +16,6 @@ public class AssertionsStatRecord
     public int TotalCount { get; set; }
     
     public int AutomatedCount { get; set; }
+    
+    public int ProblemCount { get; set; }
 }

--- a/SpecBox.Domain/Model/Enums/AutomationState.cs
+++ b/SpecBox.Domain/Model/Enums/AutomationState.cs
@@ -1,0 +1,8 @@
+namespace SpecBox.Domain.Model.Enums;
+
+public enum AutomationState
+{
+    Unknown = 0,
+    Automated = 1,
+    Problem = 2,
+}

--- a/SpecBox.Domain/Model/Enums/FeatureType.cs
+++ b/SpecBox.Domain/Model/Enums/FeatureType.cs
@@ -1,0 +1,7 @@
+namespace SpecBox.Domain.Model.Enums;
+
+public enum FeatureType
+{
+    Functional = 1,
+    Visual = 2,
+}

--- a/SpecBox.Domain/Model/Feature.cs
+++ b/SpecBox.Domain/Model/Feature.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using SpecBox.Domain.Model.Enums;
 
 namespace SpecBox.Domain.Model;
 
@@ -7,14 +8,16 @@ public class Feature
 {
     public Guid Id { get; set; }
     public string Code { get; set; } = null!;
+
+    public FeatureType? FeatureType { get; set; }
     public string Title { get; set; } = null!;
     public string? Description { get; set; }
-    
+
     public string? FilePath { get; set; }
 
     public Guid ProjectId { get; set; }
     public Project Project { get; set; } = null!;
-    
+
     public List<AttributeValue> Attributes { get; } = new();
 
     public List<AssertionGroup> AssertionGroups { get; } = new();

--- a/SpecBox.Domain/Model/TreeNode.cs
+++ b/SpecBox.Domain/Model/TreeNode.cs
@@ -10,6 +10,7 @@ public class TreeNode
     public string? Title { get; set; }
     public int Amount { get; set; }
     public int AmountAutomated { get; set; }
+    public int AmountProblem { get; set; }
     public int? SortOrder { get; set; }
 
     public Guid? FeatureId { get; set; } = null!;

--- a/SpecBox.Migrations/Migration_011_FeatureTypeAndAssertionState.cs
+++ b/SpecBox.Migrations/Migration_011_FeatureTypeAndAssertionState.cs
@@ -1,0 +1,19 @@
+using System.Data;
+using ThinkingHome.Migrator.Framework;
+
+namespace SpecBox.Migrations;
+
+[Migration(11)]
+public class Migration_011_FeatureTypeAndAssertionState : Migration
+{
+    public override void Apply()
+    {
+        Database.AddColumn("Feature", new Column("FeatureType", DbType.Int32, ColumnProperty.Null));
+
+        Database.AddColumn("Assertion", new Column("AutomationState", DbType.Int32, ColumnProperty.NotNull, 0));
+
+        Database.Update("Assertion", new[] { "AutomationState" }, new[] { "1" }, "\"IsAutomated\" = true");
+
+        Database.RemoveColumn("Assertion", "IsAutomated");
+    }
+}

--- a/SpecBox.Migrations/Migration_012_ExportTables.cs
+++ b/SpecBox.Migrations/Migration_012_ExportTables.cs
@@ -1,0 +1,17 @@
+using System.Data;
+using ThinkingHome.Migrator.Framework;
+
+namespace SpecBox.Migrations;
+
+[Migration(12)]
+public class Migration_012_ExportTables : Migration
+{
+    public override void Apply()
+    {
+        Database.AddColumn("ExportFeature", new Column("FeatureType", DbType.Int32, ColumnProperty.Null));
+        
+        Database.AddColumn("ExportAssertion", new Column("AutomationState", DbType.Int32, ColumnProperty.NotNull, 0));
+
+        Database.RemoveColumn("ExportAssertion", "IsAutomated");
+    }
+}

--- a/SpecBox.Migrations/Migration_013_TreeNodes.cs
+++ b/SpecBox.Migrations/Migration_013_TreeNodes.cs
@@ -1,0 +1,15 @@
+using System.Data;
+using ThinkingHome.Migrator.Framework;
+
+namespace SpecBox.Migrations;
+
+[Migration(13)]
+public class Migration_013_TreeNodes : Migration
+{
+    public override void Apply()
+    {
+        Database.AddColumn("TreeNode", new Column("AmountProblem", DbType.Int32, ColumnProperty.NotNull, 0));
+        Database.ExecuteFromResource(GetType().Assembly, "SpecBox.Migrations.Resources.013_MergeExportedData.sql");
+        Database.ExecuteFromResource(GetType().Assembly, "SpecBox.Migrations.Resources.013_BuildTree.sql");
+    }
+}

--- a/SpecBox.Migrations/Migration_014_AssertionsStat.cs
+++ b/SpecBox.Migrations/Migration_014_AssertionsStat.cs
@@ -1,0 +1,13 @@
+using System.Data;
+using ThinkingHome.Migrator.Framework;
+
+namespace SpecBox.Migrations;
+
+[Migration(14)]
+public class Migration_014_AssertionsStat : Migration
+{
+    public override void Apply()
+    {
+        Database.AddColumn("AssertionsStat", new Column("ProblemCount", DbType.Int32, ColumnProperty.NotNull, 0));
+    }
+}

--- a/SpecBox.Migrations/Resources/013_BuildTree.sql
+++ b/SpecBox.Migrations/Resources/013_BuildTree.sql
@@ -1,0 +1,197 @@
+CREATE
+OR REPLACE PROCEDURE public."BuildTree" ("v_ProjectId" uuid)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+DROP TABLE IF EXISTS temp_features;
+DROP TABLE IF EXISTS temp_path_to_feature;
+DROP TABLE IF EXISTS temp_tree_ids;
+DROP TABLE IF EXISTS temp_unique_path_to_feature;
+
+CREATE
+TEMPORARY TABLE temp_path_to_feature (
+	"TreeId" uuid,
+	"AttributeValueId" uuid,
+	"AttributeValue" VARCHAR(400),
+	"Order" int,
+	"FeatureId" uuid,
+	"FeatureTitle" VARCHAR(400),
+	"Amount" INT,
+	"AmountAutomated" INT,
+	"Path" TEXT,
+	"Key" TEXT
+);
+
+CREATE
+TEMPORARY TABLE temp_tree_ids (
+	"Id" uuid,
+	"ParentId" uuid,
+	"TreeId" uuid,
+	"AttributeValueId" uuid,
+	"Amount" INT,
+	"AmountAutomated" INT,
+	"Order" INT,
+	"Key" TEXT
+);
+
+-- Выбираем все фичи с атрибутами и уровнем группировки
+CREATE
+TEMPORARY TABLE temp_features ON COMMIT DROP
+as (
+	SELECT 
+		tree."Id" as "TreeId", 
+		MIN(attrval."Title") as "AttributeValue", 
+		attrval."Id" as "AttributeValueId", 
+		MIN(atgr."Order") as "Order", 
+		ft."Id" as "FeatureId", 
+		MIN(ft."Title") as "FeatureTitle",
+		COUNT(DISTINCT ass."Id") as "Amount",
+		COUNT(DISTINCT case when ass."IsAutomated" = TRUE then ass."Id" else NULL end) as "AmountAutomated"
+	FROM "Feature" ft
+		JOIN "FeatureAttributeValue" ftat on ftat."FeatureId" = ft."Id"
+		JOIN "AttributeValue" attrval on ftat."AttributeValueId" = attrval."Id" 
+		JOIN "AttributeGroupOrder" atgr on attrval."AttributeId" = atgr."AttributeId"
+		JOIN "Tree" tree on atgr."TreeId" = tree."Id"
+		LEFT JOIN "AssertionGroup" assgrp on assgrp."FeatureId" = ft."Id"
+			LEFT JOIN "Assertion" ass on ass."AssertionGroupId" = assgrp."Id"
+	WHERE ft."ProjectId" = "v_ProjectId" AND tree."ProjectId" = "v_ProjectId"
+	GROUP BY ft."Id", atgr."Id", tree."Id", attrval."Id"
+	UNION ALL
+-- Добавляем фичи без требуемого атрибута, это необходимо, так как на каждом уровне потребуется строка
+	SELECT 
+		tree."Id" as "TreeId", 
+		NULL as "AttributeValue", 
+		NULL as "AttributeValueId", 
+		MIN(atgr."Order") as "Order", 
+		ft."Id" as "FeatureId", 
+		MIN(ft."Title") as "FeatureTitle",
+		COUNT(DISTINCT ass."Id") as "Amount",
+		COUNT(DISTINCT case when ass."IsAutomated" = TRUE then ass."Id" else NULL end) as "AmountAutomated"
+	FROM "Feature" ft
+		LEFT JOIN "AssertionGroup" assgrp on assgrp."FeatureId" = ft."Id"
+			LEFT JOIN "Assertion" ass on ass."AssertionGroupId" = assgrp."Id"
+		CROSS JOIN "AttributeGroupOrder" atgr
+			JOIN "Tree" tree on atgr."TreeId" = tree."Id"
+	WHERE NOT EXISTS (
+		SELECT 1 FROM "FeatureAttributeValue" ftat 
+		JOIN "AttributeValue" atval on ftat."AttributeValueId" = atval."Id"
+		WHERE ftat."FeatureId" = ft."Id" AND atval."AttributeId" = atgr."AttributeId"
+	) AND ft."ProjectId" = "v_ProjectId" AND tree."ProjectId" = "v_ProjectId"
+	GROUP BY ft."Id", atgr."Id", tree."Id"
+);
+
+-- -- Строим рекурсивно пути к каждой фиче через склевание AttributeValueId
+WITH RECURSIVE path_to_feature AS (SELECT tf."TreeId"                                      as "TreeId",
+                                          tf."AttributeValueId"                            as "AttributeValueId",
+                                          MAX(tf."AttributeValue")                         as "AttributeValue",
+                                          tf."Order"                                       as "Order",
+                                          tf."FeatureId"                                   as "FeatureId",
+                                          MAX(tf."FeatureTitle")                           as "FeatureTitle",
+                                          SUM(tf."Amount")                                 as "Amount",
+                                          SUM(tf."AmountAutomated")                        as "AmountAutomated",
+                                          COALESCE(MAX(tf."AttributeValue"), 'ND')         as "Path",
+                                          COALESCE(tf."AttributeValueId"::varchar, 'NULL') as "Key"
+
+                                   FROM temp_features as tf
+                                   WHERE "Order" = 1
+                                   GROUP BY "TreeId", "AttributeValueId", "Order", "FeatureId"
+
+                                   UNION ALL
+
+                                   SELECT tf."TreeId"                                                          as "TreeId",
+                                          tf."AttributeValueId"                                                as "AttributeValueId",
+                                          tf."AttributeValue"                                                  as "AttributeValue",
+                                          tf."Order"                                                           as "Order",
+                                          tf."FeatureId"                                                       as "FeatureId",
+                                          tf."FeatureTitle"                                                    as "FeatureTitle",
+                                          tf."Amount"                                                          as "Amount",
+                                          tf."AmountAutomated"                                                 as "AmountAutomated",
+                                          ptf."Path" || '->' || COALESCE(tf."AttributeValue", 'ND')            as "Path",
+                                          ptf."Key" || '.' || COALESCE(tf."AttributeValueId"::varchar, 'NULL') as "Key"
+
+                                   FROM temp_features as tf
+                                            JOIN path_to_feature as ptf ON ptf."TreeId" = tf."TreeId"
+                                       AND ptf."Order" + 1 = tf."Order"
+                                       AND ptf."FeatureId" = tf."FeatureId")
+INSERT
+INTO temp_path_to_feature
+SELECT *
+FROM path_to_feature;
+
+-- Когда у нас появились уникальные пути к каждой фиче мы можем сгенерировать Id и PrentId для каждого TreeNode
+WITH RECURSIVE tree_ids AS (SELECT gen_random_uuid()      as "Id",
+                                   NULL::uuid as "ParentId", ptf."TreeId" as "TreeId",
+                                   ptf."AttributeValueId" as "AttributeValueId",
+                                   ptf."Key"              as "Key"
+                            FROM temp_path_to_feature as ptf
+                            WHERE "Order" = 1
+                            GROUP BY ptf."TreeId", ptf."AttributeValueId", ptf."Key"
+
+                            UNION ALL
+
+                            SELECT gen_random_uuid()      as "Id",
+                                   tids."Id"              as "ParentId",
+                                   ptf."TreeId",
+                                   ptf."AttributeValueId" as "AttributeValueId",
+                                   ptf."Key"              as "Key"
+                            FROM temp_path_to_feature as ptf
+                                     JOIN tree_ids tids on tids."Key" = SUBSTRING(ptf."Key" FROM '^(.*)\.')
+                                AND tids."TreeId" = ptf."TreeId"
+                            GROUP BY ptf."TreeId", ptf."AttributeValueId", tids."Id", ptf."Key")
+INSERT
+INTO temp_tree_ids
+SELECT tids."Id",
+       tids."ParentId",
+       tids."TreeId",
+       tids."AttributeValueId",
+       SUM(ptf."Amount")          as "Amount",
+       SUM(ptf."AmountAutomated") as "AmountAutomated",
+       MAX(ptf."Order"),
+       tids."Key"
+FROM tree_ids as tids
+         JOIN temp_path_to_feature ptf on tids."Key" = ptf."Key"
+GROUP BY tids."Id", tids."ParentId", tids."TreeId", tids."AttributeValueId", tids."Key";
+
+DELETE
+FROM "TreeNode"
+WHERE "TreeId" in (SELECT "Id" FROM "Tree" as tree WHERE tree."ProjectId" = "v_ProjectId");
+
+-- Data to insert to TreeNode, тут выбираем уникальные пары и вставляем, соблюдаем порядок от корня к листьям
+INSERT INTO public."TreeNode" ("Id", "ParentId", "TreeId", "Title", "Amount", "AmountAutomated", "SortOrder")
+SELECT DISTINCT tids."Id"              as "Id",
+                tids."ParentId"        as "ParentId",
+                tids."TreeId"          as "TreeId",
+                aval."Title"           as "Title",
+                tids."Amount"          as "Amount",
+                tids."AmountAutomated" as "AmountAutomated",
+                aval."SortOrder"       as "SortOrder"
+FROM temp_tree_ids as tids
+         LEFT JOIN "AttributeValue" as aval on tids."AttributeValueId" = aval."Id";
+
+-- Data to insert to TreeNode, находим самые глубокие узлы связанные с фичами и вставляем
+INSERT INTO public."TreeNode" ("ParentId", "FeatureId", "TreeId", "Title", "Amount", "AmountAutomated")
+SELECT DISTINCT
+ON (ptf."TreeId", ptf."FeatureId", tids."Id")
+    tids."Id" as "ParentId",
+    ptf."FeatureId" as "FeatureId",
+    ptf."TreeId" as "TreeId",
+    ptf."FeatureTitle" as "Title",
+    ptf."Amount" as "Amount",
+    ptf."AmountAutomated" as "AmountAutomated"
+FROM temp_tree_ids as tids
+    JOIN (
+    SELECT
+    "Key", "TreeId", "FeatureId", MAX ("FeatureTitle") as "FeatureTitle", MAX ("Amount") as "Amount", MAX ("AmountAutomated") as "AmountAutomated", MAX ("Order") as "Order"
+    FROM temp_path_to_feature
+    GROUP BY "TreeId", "FeatureId", "Key"
+    ) as ptf
+on tids."Key" = ptf."Key" AND tids."Order" = ptf."Order"
+
+-- Фильтруем только самые глубокие пути для каждого дерева
+    JOIN (
+    SELECT "TreeId", MAX ("Order") as "MaxOrder"
+    FROM temp_path_to_feature
+    GROUP BY "TreeId"
+    ) as deepest_filter on tids."Order" = deepest_filter."MaxOrder" AND tids."TreeId" = deepest_filter."TreeId";
+
+END;$$

--- a/SpecBox.Migrations/Resources/013_MergeExportedData.sql
+++ b/SpecBox.Migrations/Resources/013_MergeExportedData.sql
@@ -22,7 +22,7 @@ BEGIN
     (
         code        varchar not null,
         title       varchar not null,
-		featureType integer,
+        featureType integer,
         description varchar,
         filePath    varchar
     ) ON COMMIT DROP;

--- a/SpecBox.Migrations/Resources/013_MergeExportedData.sql
+++ b/SpecBox.Migrations/Resources/013_MergeExportedData.sql
@@ -1,0 +1,250 @@
+CREATE OR REPLACE PROCEDURE public."MergeExportedData"(exportId uuid)
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    projectId uuid;
+    rowsCount integer;
+BEGIN
+    -- ## ID ПРОЕКТА
+    SELECT "ProjectId"
+    INTO projectId
+    FROM public."Export"
+    WHERE "Id" = exportId;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Export % is not found', exportId;
+    END IF;
+
+    -- ## ЭКСПОРТ ФИЧЕЙ
+    -- создаем временную таблицу фичей
+    CREATE TEMPORARY TABLE tmp_feature
+    (
+        code        varchar not null,
+        title       varchar not null,
+		featureType integer,
+        description varchar,
+        filePath    varchar
+    ) ON COMMIT DROP;
+
+    -- заполняем данными временную таблицу фичей
+    INSERT INTO tmp_feature (code, title, featureType, description, filePath)
+    SELECT "Code", "Title", "FeatureType", "Description", "FilePath"
+    FROM public."ExportFeature"
+    WHERE "ExportId" = exportId;
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'exported features: %', rowsCount;
+
+    -- обновляем таблицу фичей
+    MERGE INTO public."Feature" f
+    USING tmp_feature t
+    ON f."Code" = t.code AND f."ProjectId" = projectId
+    WHEN MATCHED THEN
+        UPDATE
+        SET "Title"       = t.title,
+            "FeatureType" = t.featureType,
+            "Description" = t.description,
+            "FilePath"    = t.filePath
+    WHEN NOT MATCHED THEN
+        INSERT ("ProjectId", "Code", "Title", "FeatureType", "Description", "FilePath")
+        VALUES (projectId, t.code, t.title, t.featureType, t.description, t.filePath);
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'updated features: %', rowsCount;
+
+    -- ## ЭКСПОРТ ГРУПП
+    -- создаем временную таблицу групп
+    CREATE TEMPORARY TABLE tmp_group
+    (
+        featureId   uuid    not null,
+        featureCode varchar not null,
+        title       varchar not null
+    ) ON COMMIT DROP;
+
+    -- заполняем данными временную таблицу групп
+    INSERT INTO tmp_group (featureId, featureCode, title)
+    SELECT f."Id", ea."FeatureCode", ea."GroupTitle"
+    FROM public."ExportAssertion" ea
+             JOIN public."Feature" f ON ea."FeatureCode" = f."Code" AND f."ProjectId" = projectId
+    WHERE ea."ExportId" = exportId
+    GROUP BY f."Id", ea."FeatureCode", ea."GroupTitle";
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'exported groups: %', rowsCount;
+
+    -- обновляем таблицу групп
+    MERGE INTO public."AssertionGroup" gr
+    USING tmp_group t
+    ON gr."FeatureId" = t.featureId AND gr."Title" = t.title
+    WHEN NOT MATCHED THEN
+        INSERT ("FeatureId", "Title")
+        VALUES (t.featureId, t.title);
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'added groups: %', rowsCount;
+
+    -- ## ЭКСПОРТ УТВЕРЖДЕНИЙ
+    -- создаем временную таблицу утверждений
+    CREATE TEMPORARY TABLE tmp_assertion
+    (
+        groupId     uuid    not null,
+        title       varchar not null,
+        description varchar,
+		automationState integer not null
+    ) ON COMMIT DROP;
+
+    -- заполняем данными временную таблицу утверждений
+    INSERT INTO tmp_assertion (groupId, title, description, automationState)
+    SELECT gr."Id", ea."Title", ea."Description", ea."AutomationState"
+    FROM public."ExportAssertion" ea
+             JOIN public."AssertionGroup" gr ON gr."Title" = ea."GroupTitle"
+             JOIN public."Feature" f
+                  ON gr."FeatureId" = f."Id" AND f."Code" = ea."FeatureCode" AND f."ProjectId" = projectId
+    WHERE ea."ExportId" = exportId;
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'exported assertions: %', rowsCount;
+
+    -- обновляем таблицу утверждений
+    MERGE INTO public."Assertion" a
+    USING tmp_assertion t
+    ON a."Title" = t.title AND a."AssertionGroupId" = t.groupId
+    WHEN MATCHED THEN
+        UPDATE
+        SET "Description" = t.description,
+            "AutomationState" = t.automationState
+    WHEN NOT MATCHED THEN
+        INSERT ("AssertionGroupId", "Title", "Description", "AutomationState")
+        VALUES (t.groupId, t.title, t.description, t.automationState);
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'updated assertions: %', rowsCount;
+
+    -- ## ЭКСПОРТ АТРИБУТОВ ФИЧЕЙ
+    -- создаем временную таблицу атрибутов фичей
+    CREATE TEMPORARY TABLE tmp_feature_attribute
+    (
+        featureId          uuid    not null,
+        attributeId        uuid    not null,
+        attributeValueCode varchar not null
+    ) ON COMMIT DROP;
+
+    -- заполняем данными временную таблицу атрибутов фичей
+    INSERT INTO tmp_feature_attribute (featureId, attributeId, attributeValueCode)
+    SELECT f."Id" as featureId, a."Id" attributeId, fa."AttributeValueCode" as attributeValueCode
+    FROM public."ExportFeatureAttribute" fa
+             JOIN public."Feature" f ON f."Code" = fa."FeatureCode" AND f."ProjectId" = projectId
+             JOIN public."Attribute" a ON a."Code" = fa."AttributeCode" AND a."ProjectId" = projectId
+    WHERE fa."ExportId" = exportId;
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'exported feature attribute values: %', rowsCount;
+
+    -- добавляем недостающие значения в таблицу значений атрибутов
+    MERGE INTO public."AttributeValue" av
+    USING (select attributeId, attributeValueCode
+           from tmp_feature_attribute
+           group by attributeId, attributeValueCode) t
+    ON av."AttributeId" = t.attributeId AND av."Code" = t.attributeValueCode
+    WHEN NOT MATCHED THEN
+        INSERT ("AttributeId", "Code", "Title")
+        VALUES (t.attributeId, t.attributeValueCode, t.attributeValueCode);
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'added attribute values: %', rowsCount;
+
+    -- добавляем недостающие связи значений атрибутов с фичами
+    MERGE INTO public."FeatureAttributeValue" fav
+    USING (select featureId, av."Id" attributeValueId
+           from tmp_feature_attribute as x
+                    join public."AttributeValue" av
+                         on av."AttributeId" = x.attributeId and av."Code" = x.attributeValueCode) t
+    ON fav."FeatureId" = t.featureId AND fav."AttributeValueId" = t.attributeValueId
+    WHEN NOT MATCHED THEN
+        INSERT ("FeatureId", "AttributeValueId")
+        VALUES (t.featureId, t.attributeValueId);
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'added feature attribute values: %', rowsCount;
+
+    -- ## УДАЛЯЕМ НЕАКТУАЛЬНЫЕ ДАННЫЕ
+
+    DELETE
+    FROM public."TreeNode" tn
+        USING public."Feature" f
+    WHERE tn."FeatureId" = f."Id"
+      AND f."ProjectId" = projectId;
+
+    -- удаляем неактуальные связи фичей со значениями атрибутов
+    DELETE
+    FROM public."FeatureAttributeValue"
+        USING public."FeatureAttributeValue" fav
+            INNER JOIN public."Feature" f
+            ON fav."FeatureId" = f."Id" AND f."ProjectId" = projectId
+            JOIN public."AttributeValue" av ON fav."AttributeValueId" = av."Id"
+            LEFT OUTER JOIN tmp_feature_attribute t
+            ON fav."FeatureId" = t.featureId AND av."AttributeId" = t.attributeId AND av."Code" = t.attributeValueCode
+    WHERE public."FeatureAttributeValue"."FeatureId" = fav."FeatureId"
+      AND public."FeatureAttributeValue"."AttributeValueId" = av."Id"
+      AND t.featureId IS NULL;
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'deleted feature attribute values: %', rowsCount;
+
+    -- удаляем неактуальные значения атрибутов
+    DELETE
+    FROM public."AttributeValue"
+        USING public."AttributeValue" av
+            INNER JOIN public."Attribute" a ON av."AttributeId" = a."Id" AND a."ProjectId" = projectId
+            LEFT OUTER JOIN public."FeatureAttributeValue" fav ON av."Id" = fav."AttributeValueId"
+    WHERE public."AttributeValue"."Id" = av."Id"
+      AND fav."AttributeValueId" IS NULL;
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'deleted attribute values: %', rowsCount;
+
+    -- удаляем неактуальные утверждения
+    DELETE
+    FROM public."Assertion"
+        USING public."Assertion" a
+            INNER JOIN public."AssertionGroup" gr
+            ON a."AssertionGroupId" = gr."Id"
+            INNER JOIN public."Feature" f
+            ON gr."FeatureId" = f."Id" AND f."ProjectId" = projectId
+            LEFT OUTER JOIN tmp_assertion t
+            ON a."AssertionGroupId" = t.groupId AND a."Title" = t.title
+    WHERE public."Assertion"."Id" = a."Id"
+      AND t.groupId IS NULL;
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'deleted assertions: %', rowsCount;
+
+    -- удаляем неактуальные группы
+    DELETE
+    FROM public."AssertionGroup"
+        USING public."AssertionGroup" gr
+            INNER JOIN public."Feature" f
+            ON gr."FeatureId" = f."Id" AND f."ProjectId" = projectId
+            LEFT OUTER JOIN tmp_group t
+            ON gr."FeatureId" = t.featureId AND gr."Title" = t.title
+    WHERE public."AssertionGroup"."Id" = gr."Id"
+      AND t.featureId IS NULL;
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'deleted groups: %', rowsCount;
+
+    -- удаляем неактуальные фичи
+    DELETE
+    FROM public."Feature"
+        USING public."Feature" f
+            LEFT OUTER JOIN tmp_feature t
+            ON f."Code" = t.code
+    WHERE public."Feature"."Id" = f."Id"
+      AND f."ProjectId" = projectId
+      AND t.code IS NULL;
+
+    GET DIAGNOSTICS rowsCount = ROW_COUNT;
+    RAISE NOTICE 'deleted features: %', rowsCount;
+END;
+$$;

--- a/SpecBox.WebApi/Controllers/ProjectController.cs
+++ b/SpecBox.WebApi/Controllers/ProjectController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using SpecBox.Domain;
 using SpecBox.Domain.Model;
+using SpecBox.Domain.Model.Enums;
 using SpecBox.WebApi.Model.Common;
 using SpecBox.WebApi.Model.Project;
 
@@ -55,7 +56,7 @@ public class ProjectController : Controller
         var tree = await db.Trees.FirstOrDefaultAsync(t => t.ProjectId == prj.Id);
 
         var projectModel = mapper.Map<Project, ProjectModel>(prj);
-        
+
         var nodes = tree == null
             ? await GetDefaultTreeModel(project)
             : await GetTreeModel(tree);
@@ -78,7 +79,10 @@ public class ProjectController : Controller
                 Id = f.Id,
                 Title = f.Title,
                 TotalCount = f.AssertionGroups.SelectMany(gr => gr.Assertions).Count(),
-                AutomatedCount = f.AssertionGroups.SelectMany(gr => gr.Assertions).Count(a => a.IsAutomated),
+                AutomatedCount = f.AssertionGroups.SelectMany(gr => gr.Assertions)
+                    .Count(a => a.AutomationState == AutomationState.Automated),
+                ProblemCount = f.AssertionGroups.SelectMany(gr => gr.Assertions)
+                    .Count(a => a.AutomationState == AutomationState.Problem),
                 FeatureCode = f.Code,
             })
             .ToArrayAsync();

--- a/SpecBox.WebApi/Controllers/ProjectController.cs
+++ b/SpecBox.WebApi/Controllers/ProjectController.cs
@@ -78,12 +78,14 @@ public class ProjectController : Controller
             {
                 Id = f.Id,
                 Title = f.Title,
+                FeatureCode = f.Code,
+                FeatureType = f.FeatureType,
                 TotalCount = f.AssertionGroups.SelectMany(gr => gr.Assertions).Count(),
                 AutomatedCount = f.AssertionGroups.SelectMany(gr => gr.Assertions)
                     .Count(a => a.AutomationState == AutomationState.Automated),
                 ProblemCount = f.AssertionGroups.SelectMany(gr => gr.Assertions)
                     .Count(a => a.AutomationState == AutomationState.Problem),
-                FeatureCode = f.Code,
+                
             })
             .ToArrayAsync();
 
@@ -101,7 +103,9 @@ public class ProjectController : Controller
                 Title = n.Title,
                 TotalCount = n.Amount,
                 AutomatedCount = n.AmountAutomated,
+                ProblemCount = n.AmountProblem,
                 FeatureCode = n.Feature == null ? null : n.Feature.Code,
+                FeatureType = n.Feature == null ? null : n.Feature.FeatureType,
                 SortOrder = n.SortOrder,
             })
             .ToArrayAsync();

--- a/SpecBox.WebApi/Controllers/StatController.cs
+++ b/SpecBox.WebApi/Controllers/StatController.cs
@@ -62,6 +62,7 @@ public class StatController : Controller
                 assertion.ProjectId == project.Id &&
                 assertion.Timestamp >= from &&
                 assertion.Timestamp < to)
+            .OrderBy(s => s.Timestamp)
             .ToArrayAsync();
         
         var autotests = await db.AutotestsStat
@@ -69,6 +70,7 @@ public class StatController : Controller
                 assertion.ProjectId == project.Id &&
                 assertion.Timestamp >= from &&
                 assertion.Timestamp < to)
+            .OrderBy(s => s.Timestamp)
             .ToArrayAsync();
 
         var model = new StatModel

--- a/SpecBox.WebApi/Lib/AutoRestSchemaFilter.cs
+++ b/SpecBox.WebApi/Lib/AutoRestSchemaFilter.cs
@@ -1,0 +1,24 @@
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace SpecBox.WebApi.Lib;
+
+public class AutoRestSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        var type = context.Type;
+        if (type.IsEnum)
+        {
+            schema.Extensions.Add(
+                "x-ms-enum",
+                new OpenApiObject
+                {
+                    ["name"] = new OpenApiString(type.Name),
+                    ["modelAsString"] = new OpenApiBoolean(false)
+                }
+            );
+        };
+    }
+}

--- a/SpecBox.WebApi/Model/Project/AssertionModel.cs
+++ b/SpecBox.WebApi/Model/Project/AssertionModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using SpecBox.Domain.Model.Enums;
 
 namespace SpecBox.WebApi.Model.Project;
 
@@ -7,4 +8,5 @@ public class AssertionModel
     [Required] public string Title { get; set; } = null!;
     public string? Description { get; set; }
     [Required] public bool IsAutomated { get; set; }
+    [Required] public AutomationState AutomationState { get; set; }
 }

--- a/SpecBox.WebApi/Model/Project/AssertionModel.cs
+++ b/SpecBox.WebApi/Model/Project/AssertionModel.cs
@@ -7,6 +7,5 @@ public class AssertionModel
 {
     [Required] public string Title { get; set; } = null!;
     public string? Description { get; set; }
-    [Required] public bool IsAutomated { get; set; }
     [Required] public AutomationState AutomationState { get; set; }
 }

--- a/SpecBox.WebApi/Model/Project/FeatureModel.cs
+++ b/SpecBox.WebApi/Model/Project/FeatureModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using SpecBox.Domain.Model.Enums;
 
 namespace SpecBox.WebApi.Model.Project;
 
@@ -8,9 +9,11 @@ public class FeatureModel
 
     [Required] public string Title { get; set; } = null!;
 
+    public FeatureType? FeatureType { get; set; }
+
     public string? Description { get; set; }
-    
+
     public string? FilePath { get; set; }
-    
+
     [Required] public List<AssertionGroupModel> AssertionGroups { get; } = new();
 }

--- a/SpecBox.WebApi/Model/Project/TreeNodeModel.cs
+++ b/SpecBox.WebApi/Model/Project/TreeNodeModel.cs
@@ -15,6 +15,7 @@ public class TreeNodeModel
     [Required] public int TotalCount { get; set; }
 
     [Required] public int AutomatedCount { get; set; }
+    [Required] public int ProblemCount { get; set; }
 
     public int? SortOrder { get; set; }
 }

--- a/SpecBox.WebApi/Model/Project/TreeNodeModel.cs
+++ b/SpecBox.WebApi/Model/Project/TreeNodeModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using SpecBox.Domain.Model.Enums;
 
 namespace SpecBox.WebApi.Model.Project;
 
@@ -9,6 +10,8 @@ public class TreeNodeModel
     public Guid? ParentId { get; set; }
 
     public string? FeatureCode { get; set; } = null!;
+    
+    public FeatureType? FeatureType { get; set; }
 
     public string? Title { get; set; }
 

--- a/SpecBox.WebApi/Model/Stat/AssertionsStatModel.cs
+++ b/SpecBox.WebApi/Model/Stat/AssertionsStatModel.cs
@@ -9,4 +9,6 @@ public class AssertionsStatModel
     [Required] public int TotalCount { get; set; }
 
     [Required] public int AutomatedCount { get; set; }
+    
+    [Required] public int ProblemCount { get; set; }
 }

--- a/SpecBox.WebApi/Model/Upload/AssertionModel.cs
+++ b/SpecBox.WebApi/Model/Upload/AssertionModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using SpecBox.Domain.Model.Enums;
 
 namespace SpecBox.WebApi.Model.Upload;
 
@@ -6,5 +7,6 @@ public class AssertionModel
 {
     [Required] public string Title { get; set; } = null!;
     public string? Description { get; set; }
-    [Required] public bool IsAutomated { get; set; }
+    public bool? IsAutomated { get; set; }
+    public AutomationState? AutomationState { get; set; }
 }

--- a/SpecBox.WebApi/Model/Upload/FeatureModel.cs
+++ b/SpecBox.WebApi/Model/Upload/FeatureModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using SpecBox.Domain.Model.Enums;
 
 namespace SpecBox.WebApi.Model.Upload;
 
@@ -8,6 +9,8 @@ public class FeatureModel
 
     [Required] public string Title { get; set; } = null!;
 
+    public FeatureType? FeatureType { get; set; }
+    
     public string? Description { get; set; }
     
     public string? FilePath { get; set; }

--- a/SpecBox.WebApi/Program.cs
+++ b/SpecBox.WebApi/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Console;
 using SpecBox.Domain;
+using SpecBox.WebApi.Lib;
 using SpecBox.WebApi.Lib.Logging;
 using SpecBox.WebApi.Model;
 
@@ -26,6 +27,7 @@ builder.Services.AddSwaggerGen(opts =>
     opts.CustomOperationIds(a => a.RelativePath);
     opts.CustomSchemaIds(a => a.FullName);
     opts.SupportNonNullableReferenceTypes();
+    opts.SchemaFilter<AutoRestSchemaFilter>();
 });
 
 builder.Logging

--- a/SpecBox.WebApi/Program.cs
+++ b/SpecBox.WebApi/Program.cs
@@ -11,9 +11,10 @@ string? cstring = builder.Configuration.GetConnectionString("default");
 builder.Services.AddDbContext<SpecBoxDbContext>(cfg => cfg.UseNpgsql(cstring));
 
 builder.Services.AddControllers()
-    .AddJsonOptions(option =>
+    .AddJsonOptions(options =>
     {
-        option.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
     });
 
 builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
**Суть изменений:** начинаем хранить дополнительные поля, с помощью которых можно
- отображать для фичи в интерфейсе тип ФТ (функиональные, визуальные)
- отображать в интерфейсе и в статистике не только количество автоматизированных ФТ, но и количество проблем (заскипанные тесты)

1. **Изменения в БД и модели**
    - в таблицы _фичей_ и _экспорта фичей_ добавлено поле `тип фичи` (`featureType`, enum, хранится в виде числа)
    - в таблицы _ассертов_ и _экспорта ассертов_ добавлено поле `статус автоматизации` (`automationState`, enum, хранится в виде числа)
      - в таблице _ассертов_ для поля `статус автоматизации`  проставлено значение на основе поля `isAutomated`
      - поле `isAutomated` удалено
    - в хранимой процедуре экспорта добавлено копирование новых полей из экспортных таблиц в основные
    - в _tree node_ добавлено поле `количество проблем` и в хранимой процедуре формирования дерева значения полей `количество автоматизированных ФТ` и `количество проблем` вычисляются на основе поля `статус автоматизации`
    - в _таблицу статистики_ добавлено поле `количество проблем`
2. **Изменения в web api**
    - во все ручки добавлены новые поля
    - для обратной совместимости в ручке экспорта оставлено поле `IsAutomated`, но сделано опциональным. значение вычисляется на основе старого и нового полей (новое — приоритетнее)
    - настроена сериализация enum в виде строк