### PR TITLE
Serve static files

### DIFF
--- a/SpecBox.WebApi/Program.cs
+++ b/SpecBox.WebApi/Program.cs
@@ -37,6 +37,8 @@ builder.Logging
 
 var app = builder.Build();
 
+app.UseDefaultFiles();
+app.UseStaticFiles();
 app.UsePathBase(app.Configuration["pathBase"]);
 app.MapControllers();
 


### PR DESCRIPTION
Serving static files feature is required to server frontend files from back.
 